### PR TITLE
Prevent email links opening in a new window

### DIFF
--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -392,7 +392,7 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 					continue;
 
 				if ( is_email( $instance[ $profile ] ) || false !== strpos( $instance[ $profile ], 'mailto:' ) )
-	                $new_window = '';
+					$new_window = '';
 
 				if ( is_email( $instance[ $profile ] ) )
 					$output .= sprintf( $data['pattern'], 'mailto:' . esc_attr( $instance[$profile] ), $new_window );

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -391,6 +391,9 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 				if ( empty( $instance[ $profile ] ) )
 					continue;
 
+				if ( is_email( $instance[ $profile ] ) || false !== strpos( $instance[ $profile ], 'mailto:' ) )
+	                $new_window = '';
+
 				if ( is_email( $instance[ $profile ] ) )
 					$output .= sprintf( $data['pattern'], 'mailto:' . esc_attr( $instance[$profile] ), $new_window );
 				else

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -320,7 +320,7 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		foreach ( (array) $this->profiles as $profile => $data ) {
 
 			printf( '<p><label for="%s">%s:</label></p>', esc_attr( $this->get_field_id( $profile ) ), esc_attr( $data['label'] ) );
-			printf( '<p><input type="text" id="%s" name="%s" value="%s" class="widefat" />', esc_attr( $this->get_field_id( $profile ) ), esc_attr( $this->get_field_name( $profile ) ), esc_url( $instance[$profile] ) );
+			printf( '<p><input type="text" id="%s" name="%s" value="%s" class="widefat" />', esc_attr( $this->get_field_id( $profile ) ), esc_attr( $this->get_field_name( $profile ) ), $instance[$profile] );
 			printf( '</p>' );
 
 		}
@@ -352,8 +352,8 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 			}
 
 			/** Sanitize Profile URIs */
-			elseif ( array_key_exists( $key, (array) $this->profiles ) ) {
-				$newinstance[$key] = esc_url( $newinstance[$key] );
+			elseif ( array_key_exists( $key, (array) $this->profiles ) && ! is_email( $value ) ) {
+				$newinstance[ $key ] = esc_url( $newinstance[ $key ] );
 			}
 
 		}

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -382,14 +382,14 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 
 			$output = '';
 
-			$new_window = $instance['new_window'] ? 'target="_blank"' : '';
-
 			$profiles = (array) $this->profiles;
 
 			foreach ( $profiles as $profile => $data ) {
 
 				if ( empty( $instance[ $profile ] ) )
 					continue;
+
+				$new_window = $instance['new_window'] ? 'target="_blank"' : '';
 
 				if ( is_email( $instance[ $profile ] ) || false !== strpos( $instance[ $profile ], 'mailto:' ) )
 					$new_window = '';


### PR DESCRIPTION
This PR:

- Fixes https://github.com/copyblogger/simple-social-icons/issues/54 so that links entered with `mailto:` or as bare email addresses are never opened in a new window if “open links in new window?” is ticked.
- Allows bare email addresses to be saved as test@example.com, instead of being escaped to `http://test@example.com` (they are still prefixed with `mailto:` when displayed). 