### PR TITLE
Use esc_attr instead of esc_url because of % sign in URL

### DIFF
--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -564,7 +564,7 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		$markup = '<li class="ssi-' . $icon . '"><a href="%s" %s>';
 		$markup .= '<svg role="img" class="social-' . $icon . '" aria-labelledby="social-' . $icon . '-{WIDGET_INSTANCE_ID}">';
 		$markup .= '<title id="social-' . $icon . '-{WIDGET_INSTANCE_ID}' . '">' . $label . '</title>';
-		$markup .= '<use xlink:href="' . esc_url( plugin_dir_url( __FILE__ ) . 'symbol-defs.svg#social-' . $icon ) . '"></use>';
+		$markup .= '<use xlink:href="' . esc_attr( plugin_dir_url( __FILE__ ) . 'symbol-defs.svg#social-' . $icon ) . '"></use>';
 		$markup .= '</svg></a></li>';
 
 		/**


### PR DESCRIPTION
Fixes #107 

### How to test
<!-- Detailed steps to test this PR. -->
**To Reproduce**
Steps to reproduce the behavior:
1. Add the Social Icons widget to your sidebar.
2. Add some social links.
3. View the page.
4. See the warning.

`Warning: sprintf(): Too few arguments in simple-social-icons.php on line 458`

**To test the fix**
Steps to test the fix:
1. Switch to branch `fix/sprintf-issue`
2. View the page from the steps above.
4. See icons/links now show properly.

### Documentation
No documentation required.

### Suggested changelog entry
- Fixes issue where icons were not appearing
