### PR TITLE
ci: allow branch_deploy to also deply latest tag to SVN repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
     steps:
       - run:
           command: |
-            echo "export VERSION=$(grep 'Version:' /tmp/src/simple-social-icons.php | awk -F: '{print $2}' | sed 's/^\s//')" >> ${BASH_ENV}
+            echo "export VERSION=$(git -C /tmp/src describe --tags --abbrev=0)" >> ${BASH_ENV}
 
   show_pwd_info:
     description: "Show information about the current directory"
@@ -84,7 +84,7 @@ jobs:
       - attach_workspace:
           at: /tmp
       - install_dependencies
-#      - run: composer phpcs
+      # - run: composer phpcs
 
   deploy_svn_branch:
     executor: base
@@ -93,6 +93,7 @@ jobs:
       - attach_workspace:
           at: /tmp
       - svn_setup
+      - svn_create_tag
       - svn_add_changes
       - svn_commit
 

--- a/.svnignore
+++ b/.svnignore
@@ -3,3 +3,4 @@
 .gitattributes
 .svnignore
 node_modules
+.circleci


### PR DESCRIPTION
In order for "Tested Up To" changes to properly reflect in the WP Plugin repo, the latest tag directory in SVN also needs to include the changes. This PR introduces a new way of extracting the latest tag using `git describe --tags` and includes the `svn_create_tag` job in the `deploy_svn_branch` job.