### PR TITLE
fix: revert logic for getting VERSION variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
     steps:
       - run:
           command: |
-            echo "export VERSION=$(git -C /tmp/src describe --tags --abbrev=0)" >> ${BASH_ENV}
+            echo "export VERSION=$(grep 'Version:' /tmp/src/simple-social-icons.php | awk -F: '{print $2}' | sed 's/^\s//')" >> ${BASH_ENV}
 
   show_pwd_info:
     description: "Show information about the current directory"


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->
When releasing a new version of the plugin the current processes is to bump the version number in the code, merge everything from the `develop` branch to `master`, then tag the `master` branch with the new version.

The current CircleCI Config, in order to simplify our ability to copy it to other plugins, references the most recent tag in order to create the `$VERSION` environment variable.

```
VERSION=$(git -C /tmp/src describe --tags --abbrev=0)
```

While this worked with the `tag_deploy` workflow, the `branch_deploy` workflow (when something is merged into `master`) was not functioning properly. Instead of the Version number in the code matching the most recent tag, the code would be showing a new version while the tag was one behind.

This PR fixes this bug by keeping the `$VERSION` variable consistent. During a `branch_deploy` the variable will represent the new version being merged in. During a `tag_deploy` the version number in the code will match the new tag, and the environment variable.

This PR also, however, does mean that every plugin this CircleCI Config uses will need to be edited to ensure the proper file is being referenced when extracting the version number.