### PR TITLE
Add escaping where needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ executors:
     working_directory: /tmp
   php_node:
     docker:
-      - image: cimg/php:7.3-node
+      - image: cimg/php:7.3-browsers
     working_directory: /tmp/src
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ executors:
     working_directory: /tmp
   php_node:
     docker:
-      - image: cimg/php:7.3.3-node-browsers
+      - image: cimg/php:7.3-node
     working_directory: /tmp/src
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ executors:
     working_directory: /tmp
   php_node:
     docker:
-      - image: circleci/php:7.3.3-stretch-node-browsers
+      - image: cimg/php:7.3.3-node-browsers
     working_directory: /tmp/src
 
 jobs:
@@ -84,7 +84,7 @@ jobs:
       - attach_workspace:
           at: /tmp
       - install_dependencies
-      # - run: composer phpcs
+      - run: composer phpcs
 
   deploy_svn_branch:
     executor: base

--- a/.svnignore
+++ b/.svnignore
@@ -1,6 +1,7 @@
 .git
 .gitignore
 .gitattributes
+.phpcs.xml
 .svnignore
 node_modules
 .circleci

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Contributors: studiopress, nathanrice, bgardner, dreamwhisper, laurenmancke, shannonsans, modernnerd, marksabbath, damiencarbery, helgatheviking, littlerchicken, tiagohillebrandt, wpmuguru, michaelbeil, norcross, rafaltomal
 Tags: social media, social networking, social profiles
 Requires at least: 4.0
-Tested up to: 4.9
-Stable tag: 3.0.0
+Tested up to: 5.9
+Stable tag: 3.1.0
 
 This plugin allows you to insert social icons in any widget area.
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,11 @@
 		"wp-coding-standards/wpcs": "^1"
 	},
 	"config": {
-		"sort-order": true
+		"sort-order": true,
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,8 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"scripts": {
-		"phpcs": "phpcs --standard=WordPress --ignore=vendor/,node_modules/,assets/ --extensions=php -p ./",
-		"phpcs-compat": "phpcs --extensions=php --standard=PHPCompatibilityWP --ignore=vendor/,node_modules/,assets/ --runtime-set testVersion 5.6- -p ./",
-		"phpcbf": "phpcbf --standard=WordPress --ignore=vendor/,node_modules/,assets/ --extensions=php -p ./"
+		"phpcs": "phpcs",
+		"phpcbf": "phpcbf"
 	},
 	"support": {
 		"issues": "https://github.com/studiopress/simple-social-icons/issues",

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,526 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "0e0fb0ba219895d901ca50e4c3abac54",
+    "packages": [
+        {
+            "name": "composer/installers",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/d20a64ed3c94748397ff5973488761b22f6d3f19",
+                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.6.* || ^2.0",
+                "composer/semver": "^1 || ^3",
+                "phpstan/phpstan": "^0.12.55",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.3"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Eliasis",
+                "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
+                "MODX Evo",
+                "MantisBT",
+                "Mautic",
+                "Maya",
+                "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
+                "SMF",
+                "Starbug",
+                "Thelia",
+                "Whmcs",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "attogram",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "cockpit",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "eZ Platform",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "itop",
+                "joomla",
+                "known",
+                "kohana",
+                "laravel",
+                "lavalite",
+                "lithium",
+                "magento",
+                "majima",
+                "mako",
+                "mediawiki",
+                "miaoxing",
+                "modulework",
+                "modx",
+                "moodle",
+                "osclass",
+                "pantheon",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "processwire",
+                "puppet",
+                "pxcms",
+                "reindex",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "sydes",
+                "sylius",
+                "symfony",
+                "tastyigniter",
+                "typo3",
+                "wordpress",
+                "yawik",
+                "zend",
+                "zikula"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-09-13T08:19:44+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "time": "2021-02-15T10:24:51+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/d55de55f88697b9cdb94bccf04f14eb3b11cf308",
+                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "time": "2021-12-30T16:37:40+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-12-12T21:44:58+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+            },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2018-12-18T09:43:51+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^5.3 || ^7"
+    },
+    "platform-dev": {
+        "php": "^5.6 || ^7"
+    },
+    "plugin-api-version": "2.2.0"
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "description": "A simple, CSS and icon font driven social icons widget.",
     "author": "StudioPress",
     "authoruri": "http://www.studiopress.com/",
-    "version": "3.0.2",
+    "version": "3.1.0",
     "license": "GPL-2.0+",
     "licenseuri": "http://www.gnu.org/licenses/gpl-2.0.html",
     "textdomain": "simple-social-icons"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress Coding Standards for Simple Social Icons">
-
 	<rule ref="WordPress">
 		<exclude name="WordPress.Files.FileName" />
 	</rule>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for Simple Social Icons">
+
+	<rule ref="WordPress">
+		<exclude name="WordPress.Files.FileName" />
+	</rule>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="simple-social-icons"/>
+			</property>
+		</properties>
+	</rule>
+
+	<config name="testVersion" value="5.6-"/>
+	<rule ref="PHPCompatibilityWP">
+		<exclude-pattern>bin/*</exclude-pattern>
+	</rule>
+
+	<arg value="s"/>
+	<arg name="extensions" value="php"/>
+
+	<file>.</file>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/assets/*</exclude-pattern>
+</ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: studiopress, nathanrice, bgardner, dreamwhisper, laurenmancke, sha
 Tags: social media, social networking, social profiles
 Requires at least: 4.0
 Tested up to: 5.4
-Stable tag: 3.0.2
+Stable tag: 3.1.0
 
 This plugin allows you to insert social icons in any widget area.
 

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -474,7 +474,7 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 
 		if ( $output ) {
 			$output = str_replace( '{WIDGET_INSTANCE_ID}', $this->number, $output );
-			printf( '<ul class="%s">%s</ul>', esc_attr( $instance['alignment'] ), esc_html( $output ) );
+			printf( '<ul class="%s">%s</ul>', esc_attr( $instance['alignment'] ), $output ); // phpcs:ignore
 		}
 
 		echo $args['after_widget']; // phpcs:ignore

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -5,7 +5,7 @@
  * Description: A simple CSS and SVG driven social icons widget.
  * Author: StudioPress
  * Author URI: https://www.studiopress.com/
- * Version: 3.0.2
+ * Version: 3.1.0
  * Text Domain: simple-social-icons
  * Domain Path: /languages
  *

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -273,8 +273,8 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 * Color Picker.
 	 *
 	 * Enqueue the color picker script.
-     *
-     * @param string $hook The current admin page.
+	 *
+	 * @param string $hook The current admin page.
 	 */
 	public function load_color_picker( $hook ) {
 		if ( 'widgets.php' !== $hook ) {
@@ -329,46 +329,46 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 *
 	 * @param array $instance The widget settings.
 	 */
-	function form( $instance ) {
+	public function form( $instance ) {
 
 		/** Merge with defaults */
 		$instance = wp_parse_args( (array) $instance, $this->defaults );
 		?>
 
-		<p><label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'simple-social-icons' ); ?></label> <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" /></p>
+		<p><label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'simple-social-icons' ); ?></label> <input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" /></p>
 
-		<p><label><input id="<?php echo $this->get_field_id( 'new_window' ); ?>" type="checkbox" name="<?php echo $this->get_field_name( 'new_window' ); ?>" value="1" <?php checked( 1, $instance['new_window'] ); ?>/> <?php esc_html_e( 'Open links in new window?', 'simple-social-icons' ); ?></label></p>
+		<p><label><input id="<?php echo esc_attr( $this->get_field_id( 'new_window' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'new_window' ) ); ?>" value="1" <?php checked( 1, $instance['new_window'] ); ?>/> <?php esc_html_e( 'Open links in new window?', 'simple-social-icons' ); ?></label></p>
 
 		<?php if ( ! $this->disable_css_output ) { ?>
 
-			<p><label for="<?php echo $this->get_field_id( 'size' ); ?>"><?php _e( 'Icon Size', 'simple-social-icons' ); ?>:</label> <input id="<?php echo $this->get_field_id( 'size' ); ?>" name="<?php echo $this->get_field_name( 'size' ); ?>" type="text" value="<?php echo esc_attr( $instance['size'] ); ?>" size="3" />px</p>
+			<p><label for="<?php echo esc_attr( $this->get_field_id( 'size' ) ); ?>"><?php esc_html_e( 'Icon Size', 'simple-social-icons' ); ?>:</label> <input id="<?php echo esc_attr( $this->get_field_id( 'size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'size' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['size'] ); ?>" size="3" />px</p>
 
-			<p><label for="<?php echo $this->get_field_id( 'border_radius' ); ?>"><?php _e( 'Icon Border Radius:', 'simple-social-icons' ); ?></label> <input id="<?php echo $this->get_field_id( 'border_radius' ); ?>" name="<?php echo $this->get_field_name( 'border_radius' ); ?>" type="text" value="<?php echo esc_attr( $instance['border_radius'] ); ?>" size="3" />px</p>
+			<p><label for="<?php echo esc_attr( $this->get_field_id( 'border_radius' ) ); ?>"><?php esc_html_e( 'Icon Border Radius:', 'simple-social-icons' ); ?></label> <input id="<?php echo esc_attr( $this->get_field_id( 'border_radius' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'border_radius' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['border_radius'] ); ?>" size="3" />px</p>
 
-			<p><label for="<?php echo $this->get_field_id( 'border_width' ); ?>"><?php _e( 'Border Width:', 'simple-social-icons' ); ?></label> <input id="<?php echo $this->get_field_id( 'border_width' ); ?>" name="<?php echo $this->get_field_name( 'border_width' ); ?>" type="text" value="<?php echo esc_attr( $instance['border_width'] ); ?>" size="3" />px</p>
+			<p><label for="<?php echo esc_attr( $this->get_field_id( 'border_width' ) ); ?>"><?php esc_html_e( 'Border Width:', 'simple-social-icons' ); ?></label> <input id="<?php echo esc_attr( $this->get_field_id( 'border_width' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'border_width' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['border_width'] ); ?>" size="3" />px</p>
 
 			<p>
-				<label for="<?php echo $this->get_field_id( 'alignment' ); ?>"><?php _e( 'Alignment', 'simple-social-icons' ); ?>:</label>
-				<select id="<?php echo $this->get_field_id( 'alignment' ); ?>" name="<?php echo $this->get_field_name( 'alignment' ); ?>">
-					<option value="alignleft" <?php selected( 'alignright', $instance['alignment'] ); ?>><?php _e( 'Align Left', 'simple-social-icons' ); ?></option>
-					<option value="aligncenter" <?php selected( 'aligncenter', $instance['alignment'] ); ?>><?php _e( 'Align Center', 'simple-social-icons' ); ?></option>
-					<option value="alignright" <?php selected( 'alignright', $instance['alignment'] ); ?>><?php _e( 'Align Right', 'simple-social-icons' ); ?></option>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'alignment' ) ); ?>"><?php esc_html_e( 'Alignment', 'simple-social-icons' ); ?>:</label>
+				<select id="<?php echo esc_attr( $this->get_field_id( 'alignment' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'alignment' ) ); ?>">
+					<option value="alignleft" <?php selected( 'alignright', $instance['alignment'] ); ?>><?php esc_html_e( 'Align Left', 'simple-social-icons' ); ?></option>
+					<option value="aligncenter" <?php selected( 'aligncenter', $instance['alignment'] ); ?>><?php esc_html_e( 'Align Center', 'simple-social-icons' ); ?></option>
+					<option value="alignright" <?php selected( 'alignright', $instance['alignment'] ); ?>><?php esc_html_e( 'Align Right', 'simple-social-icons' ); ?></option>
 				</select>
 			</p>
 
 			<hr style="background: #ccc; border: 0; height: 1px; margin: 20px 0;" />
 
-			<p><label for="<?php echo $this->get_field_id( 'background_color' ); ?>"><?php _e( 'Icon Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo $this->get_field_id( 'icon_color' ); ?>" name="<?php echo $this->get_field_name( 'icon_color' ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['icon_color'] ); ?>" value="<?php echo esc_attr( $instance['icon_color'] ); ?>" size="6" /></p>
+			<p><label for="<?php echo esc_attr( $this->get_field_id( 'background_color' ) ); ?>"><?php esc_html_e( 'Icon Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo esc_attr( $this->get_field_id( 'icon_color' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'icon_color' ) ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['icon_color'] ); ?>" value="<?php echo esc_attr( $instance['icon_color'] ); ?>" size="6" /></p>
 
-			<p><label for="<?php echo $this->get_field_id( 'background_color_hover' ); ?>"><?php _e( 'Icon Hover Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo $this->get_field_id( 'icon_color_hover' ); ?>" name="<?php echo $this->get_field_name( 'icon_color_hover' ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['icon_color_hover'] ); ?>" value="<?php echo esc_attr( $instance['icon_color_hover'] ); ?>" size="6" /></p>
+			<p><label for="<?php echo esc_attr( $this->get_field_id( 'background_color_hover' ) ); ?>"><?php esc_html_e( 'Icon Hover Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo esc_attr( $this->get_field_id( 'icon_color_hover' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'icon_color_hover' ) ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['icon_color_hover'] ); ?>" value="<?php echo esc_attr( $instance['icon_color_hover'] ); ?>" size="6" /></p>
 
-			<p><label for="<?php echo $this->get_field_id( 'background_color' ); ?>"><?php _e( 'Background Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo $this->get_field_id( 'background_color' ); ?>" name="<?php echo $this->get_field_name( 'background_color' ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['background_color'] ); ?>" value="<?php echo esc_attr( $instance['background_color'] ); ?>" size="6" /></p>
+			<p><label for="<?php echo esc_attr( $this->get_field_id( 'background_color' ) ); ?>"><?php esc_html_e( 'Background Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo esc_attr( $this->get_field_id( 'background_color' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'background_color' ) ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['background_color'] ); ?>" value="<?php echo esc_attr( $instance['background_color'] ); ?>" size="6" /></p>
 
-			<p><label for="<?php echo $this->get_field_id( 'background_color_hover' ); ?>"><?php _e( 'Background Hover Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo $this->get_field_id( 'background_color_hover' ); ?>" name="<?php echo $this->get_field_name( 'background_color_hover' ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['background_color_hover'] ); ?>" value="<?php echo esc_attr( $instance['background_color_hover'] ); ?>" size="6" /></p>
+			<p><label for="<?php echo esc_attr( $this->get_field_id( 'background_color_hover' ) ); ?>"><?php esc_html_e( 'Background Hover Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo esc_attr( $this->get_field_id( 'background_color_hover' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'background_color_hover' ) ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['background_color_hover'] ); ?>" value="<?php echo esc_attr( $instance['background_color_hover'] ); ?>" size="6" /></p>
 
-			<p><label for="<?php echo $this->get_field_id( 'border_color' ); ?>"><?php _e( 'Border Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo $this->get_field_id( 'border_color' ); ?>" name="<?php echo $this->get_field_name( 'border_color' ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['border_color'] ); ?>" value="<?php echo esc_attr( $instance['border_color'] ); ?>" size="6" /></p>
+			<p><label for="<?php echo esc_attr( $this->get_field_id( 'border_color' ) ); ?>"><?php esc_html_e( 'Border Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo esc_attr( $this->get_field_id( 'border_color' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'border_color' ) ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['border_color'] ); ?>" value="<?php echo esc_attr( $instance['border_color'] ); ?>" size="6" /></p>
 
-			<p><label for="<?php echo $this->get_field_id( 'border_color_hover' ); ?>"><?php _e( 'Border Hover Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo $this->get_field_id( 'border_color_hover' ); ?>" name="<?php echo $this->get_field_name( 'border_color_hover' ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['border_color_hover'] ); ?>" value="<?php echo esc_attr( $instance['border_color_hover'] ); ?>" size="6" /></p>
+			<p><label for="<?php echo esc_attr( $this->get_field_id( 'border_color_hover' ) ); ?>"><?php esc_html_e( 'Border Hover Color:', 'simple-social-icons' ); ?></label><br /> <input id="<?php echo esc_attr( $this->get_field_id( 'border_color_hover' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'border_color_hover' ) ); ?>" type="text" class="ssiw-color-picker" data-default-color="<?php echo esc_attr( $this->defaults['border_color_hover'] ); ?>" value="<?php echo esc_attr( $instance['border_color_hover'] ); ?>" size="6" /></p>
 
 			<hr style="background: #ccc; border: 0; height: 1px; margin: 20px 0;" />
 		<?php } ?>
@@ -377,7 +377,7 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		foreach ( (array) $this->profiles as $profile => $data ) {
 
 			printf( '<p><label for="%s">%s:</label></p>', esc_attr( $this->get_field_id( $profile ) ), esc_attr( $data['label'] ) );
-			printf( '<p><input type="text" id="%s" name="%s" value="%s" class="widefat" />', esc_attr( $this->get_field_id( $profile ) ), esc_attr( $this->get_field_name( $profile ) ), $instance[ $profile ] );
+			printf( '<p><input type="text" id="%s" name="%s" value="%s" class="widefat" />', esc_attr( $this->get_field_id( $profile ) ), esc_attr( $this->get_field_name( $profile ) ), esc_attr( $instance[ $profile ] ) );
 			printf( '</p>' );
 
 		}

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -11,7 +11,7 @@
  *
  * License: GNU General Public License v2.0 (or later)
  * License URI: https://www.opensource.org/licenses/gpl-license.php
- * 
+ *
  * @package simple-social-icons
  */
 
@@ -81,42 +81,45 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		 *
 		 * @param array $defaults Default widget options.
 		 */
-		$this->defaults = apply_filters( 'simple_social_default_styles', array(
-			'title'                  => '',
-			'new_window'             => 0,
-			'size'                   => 36,
-			'border_radius'          => 3,
-			'border_width'           => 0,
-			'border_color'           => '#ffffff',
-			'border_color_hover'     => '#ffffff',
-			'icon_color'             => '#ffffff',
-			'icon_color_hover'       => '#ffffff',
-			'background_color'       => '#999999',
-			'background_color_hover' => '#666666',
-			'alignment'              => 'alignleft',
-			'behance'                => '',
-			'bloglovin'              => '',
-			'dribbble'               => '',
-			'email'                  => '',
-			'facebook'               => '',
-			'flickr'                 => '',
-			'github'                 => '',
-			'gplus'                  => '',
-			'instagram'              => '',
-			'linkedin'               => '',
-			'medium'                 => '',
-			'periscope'              => '',
-			'phone'                  => '',
-			'pinterest'              => '',
-			'rss'                    => '',
-			'snapchat'               => '',
-			'stumbleupon'            => '',
-			'tumblr'                 => '',
-			'twitter'                => '',
-			'vimeo'                  => '',
-			'xing'                   => '',
-			'youtube'                => '',
-		) );
+		$this->defaults = apply_filters(
+			'simple_social_default_styles',
+			array(
+				'title'                  => '',
+				'new_window'             => 0,
+				'size'                   => 36,
+				'border_radius'          => 3,
+				'border_width'           => 0,
+				'border_color'           => '#ffffff',
+				'border_color_hover'     => '#ffffff',
+				'icon_color'             => '#ffffff',
+				'icon_color_hover'       => '#ffffff',
+				'background_color'       => '#999999',
+				'background_color_hover' => '#666666',
+				'alignment'              => 'alignleft',
+				'behance'                => '',
+				'bloglovin'              => '',
+				'dribbble'               => '',
+				'email'                  => '',
+				'facebook'               => '',
+				'flickr'                 => '',
+				'github'                 => '',
+				'gplus'                  => '',
+				'instagram'              => '',
+				'linkedin'               => '',
+				'medium'                 => '',
+				'periscope'              => '',
+				'phone'                  => '',
+				'pinterest'              => '',
+				'rss'                    => '',
+				'snapchat'               => '',
+				'stumbleupon'            => '',
+				'tumblr'                 => '',
+				'twitter'                => '',
+				'vimeo'                  => '',
+				'xing'                   => '',
+				'youtube'                => '',
+			)
+		);
 
 		/**
 		 * Filter for social profile choices.
@@ -125,96 +128,99 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		 *
 		 * @param array $profiles Social icons to include in widget options.
 		 */
-		$this->profiles = apply_filters( 'simple_social_default_profiles', array(
-			'behance' => array(
-				'label'   => __( 'Behance URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'behance', __( 'Behance', 'simple-social-icons' ) ),
-			),
-			'bloglovin' => array(
-				'label'   => __( 'Bloglovin URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'bloglovin', __( 'Bloglovin', 'simple-social-icons' ) ),
-			),
-			'dribbble' => array(
-				'label'   => __( 'Dribbble URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'dribbble', __( 'Dribbble', 'simple-social-icons' ) ),
-			),
-			'email' => array(
-				'label'   => __( 'Email URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'email', __( 'Email', 'simple-social-icons' ) ),
-			),
-			'facebook' => array(
-				'label'   => __( 'Facebook URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'facebook', __( 'Facebook', 'simple-social-icons' ) ),
-			),
-			'flickr' => array(
-				'label'   => __( 'Flickr URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'flickr', __( 'Flickr', 'simple-social-icons' ) ),
-			),
-			'github' => array(
-				'label'   => __( 'GitHub URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'github', __( 'GitHub', 'simple-social-icons' ) ),
-			),
-			'gplus' => array(
-				'label'   => __( 'Google+ URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'gplus', __( 'Google+', 'simple-social-icons' ) ),
-			),
-			'instagram' => array(
-				'label'   => __( 'Instagram URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'instagram', __( 'Instagram', 'simple-social-icons' ) ),
-			),
-			'linkedin' => array(
-				'label'   => __( 'Linkedin URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'linkedin', __( 'LinkedIn', 'simple-social-icons' ) ),
-			),
-			'medium' => array(
-				'label'   => __( 'Medium URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'medium', __( 'Medium', 'simple-social-icons' ) ),
-			),
-			'periscope' => array(
-				'label'   => __( 'Periscope URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'periscope', __( 'Periscope', 'simple-social-icons' ) ),
-			),
-			'phone' => array(
-				'label'   => __( 'Phone URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'phone', __( 'Phone', 'simple-social-icons' ) ),
-			),
-			'pinterest' => array(
-				'label'   => __( 'Pinterest URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'pinterest', __( 'Pinterest', 'simple-social-icons' ) ),
-			),
-			'rss' => array(
-				'label'   => __( 'RSS URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'rss', __( 'RSS', 'simple-social-icons' ) ),
-			),
-			'snapchat' => array(
-				'label'   => __( 'Snapchat URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'snapchat', __( 'Snapchat', 'simple-social-icons' ) ),
-			),
-			'stumbleupon' => array(
-				'label'   => __( 'StumbleUpon URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'stumbleupon', __( 'StumbleUpon', 'simple-social-icons' ) ),
-			),
-			'tumblr' => array(
-				'label'   => __( 'Tumblr URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'tumblr', __( 'Tumblr', 'simple-social-icons' ) ),
-			),
-			'twitter' => array(
-				'label'   => __( 'Twitter URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'twitter', __( 'Twitter', 'simple-social-icons' ) ),
-			),
-			'vimeo' => array(
-				'label'   => __( 'Vimeo URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'vimeo', __( 'Vimeo', 'simple-social-icons' ) ),
-			),
-			'xing' => array(
-				'label'   => __( 'Xing URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'xing', __( 'xing', 'simple-social-icons' ) ),
-			),
-			'youtube' => array(
-				'label'   => __( 'YouTube URI', 'simple-social-icons' ),
-				'pattern' => $this->get_icon_markup( 'youtube', __( 'YouTube', 'simple-social-icons' ) ),
-			),
-		) );
+		$this->profiles = apply_filters(
+			'simple_social_default_profiles',
+			array(
+				'behance'     => array(
+					'label'   => __( 'Behance URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'behance', __( 'Behance', 'simple-social-icons' ) ),
+				),
+				'bloglovin'   => array(
+					'label'   => __( 'Bloglovin URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'bloglovin', __( 'Bloglovin', 'simple-social-icons' ) ),
+				),
+				'dribbble'    => array(
+					'label'   => __( 'Dribbble URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'dribbble', __( 'Dribbble', 'simple-social-icons' ) ),
+				),
+				'email'       => array(
+					'label'   => __( 'Email URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'email', __( 'Email', 'simple-social-icons' ) ),
+				),
+				'facebook'    => array(
+					'label'   => __( 'Facebook URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'facebook', __( 'Facebook', 'simple-social-icons' ) ),
+				),
+				'flickr'      => array(
+					'label'   => __( 'Flickr URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'flickr', __( 'Flickr', 'simple-social-icons' ) ),
+				),
+				'github'      => array(
+					'label'   => __( 'GitHub URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'github', __( 'GitHub', 'simple-social-icons' ) ),
+				),
+				'gplus'       => array(
+					'label'   => __( 'Google+ URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'gplus', __( 'Google+', 'simple-social-icons' ) ),
+				),
+				'instagram'   => array(
+					'label'   => __( 'Instagram URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'instagram', __( 'Instagram', 'simple-social-icons' ) ),
+				),
+				'linkedin'    => array(
+					'label'   => __( 'Linkedin URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'linkedin', __( 'LinkedIn', 'simple-social-icons' ) ),
+				),
+				'medium'      => array(
+					'label'   => __( 'Medium URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'medium', __( 'Medium', 'simple-social-icons' ) ),
+				),
+				'periscope'   => array(
+					'label'   => __( 'Periscope URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'periscope', __( 'Periscope', 'simple-social-icons' ) ),
+				),
+				'phone'       => array(
+					'label'   => __( 'Phone URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'phone', __( 'Phone', 'simple-social-icons' ) ),
+				),
+				'pinterest'   => array(
+					'label'   => __( 'Pinterest URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'pinterest', __( 'Pinterest', 'simple-social-icons' ) ),
+				),
+				'rss'         => array(
+					'label'   => __( 'RSS URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'rss', __( 'RSS', 'simple-social-icons' ) ),
+				),
+				'snapchat'    => array(
+					'label'   => __( 'Snapchat URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'snapchat', __( 'Snapchat', 'simple-social-icons' ) ),
+				),
+				'stumbleupon' => array(
+					'label'   => __( 'StumbleUpon URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'stumbleupon', __( 'StumbleUpon', 'simple-social-icons' ) ),
+				),
+				'tumblr'      => array(
+					'label'   => __( 'Tumblr URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'tumblr', __( 'Tumblr', 'simple-social-icons' ) ),
+				),
+				'twitter'     => array(
+					'label'   => __( 'Twitter URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'twitter', __( 'Twitter', 'simple-social-icons' ) ),
+				),
+				'vimeo'       => array(
+					'label'   => __( 'Vimeo URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'vimeo', __( 'Vimeo', 'simple-social-icons' ) ),
+				),
+				'xing'        => array(
+					'label'   => __( 'Xing URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'xing', __( 'xing', 'simple-social-icons' ) ),
+				),
+				'youtube'     => array(
+					'label'   => __( 'YouTube URI', 'simple-social-icons' ),
+					'pattern' => $this->get_icon_markup( 'youtube', __( 'YouTube', 'simple-social-icons' ) ),
+				),
+			)
+		);
 
 		/**
 		 * Filter to disable output of custom CSS.
@@ -264,11 +270,11 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 * Color Picker.
 	 *
 	 * Enqueue the color picker script.
-	 *
 	 */
 	function load_color_picker( $hook ) {
-		if( 'widgets.php' != $hook )
+		if ( 'widgets.php' != $hook ) {
 			return;
+		}
 			wp_enqueue_style( 'wp-color-picker' );
 			wp_enqueue_script( 'wp-color-picker' );
 			wp_enqueue_script( 'underscore' );
@@ -278,7 +284,6 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 * Print scripts.
 	 *
 	 * Reference https://core.trac.wordpress.org/attachment/ticket/25809/color-picker-widget.php
-	 *
 	 */
 	function print_scripts() {
 		?>
@@ -316,7 +321,6 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 * Widget Form.
 	 *
 	 * Outputs the widget form that allows users to control the output of the widget.
-	 *
 	 */
 	function form( $instance ) {
 
@@ -339,9 +343,9 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 			<p>
 				<label for="<?php echo $this->get_field_id( 'alignment' ); ?>"><?php _e( 'Alignment', 'simple-social-icons' ); ?>:</label>
 				<select id="<?php echo $this->get_field_id( 'alignment' ); ?>" name="<?php echo $this->get_field_name( 'alignment' ); ?>">
-					<option value="alignleft" <?php selected( 'alignright', $instance['alignment'] ) ?>><?php _e( 'Align Left', 'simple-social-icons' ); ?></option>
-					<option value="aligncenter" <?php selected( 'aligncenter', $instance['alignment'] ) ?>><?php _e( 'Align Center', 'simple-social-icons' ); ?></option>
-					<option value="alignright" <?php selected( 'alignright', $instance['alignment'] ) ?>><?php _e( 'Align Right', 'simple-social-icons' ); ?></option>
+					<option value="alignleft" <?php selected( 'alignright', $instance['alignment'] ); ?>><?php _e( 'Align Left', 'simple-social-icons' ); ?></option>
+					<option value="aligncenter" <?php selected( 'aligncenter', $instance['alignment'] ); ?>><?php _e( 'Align Center', 'simple-social-icons' ); ?></option>
+					<option value="alignright" <?php selected( 'alignright', $instance['alignment'] ); ?>><?php _e( 'Align Right', 'simple-social-icons' ); ?></option>
 				</select>
 			</p>
 
@@ -377,7 +381,6 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 * Form validation and sanitization.
 	 *
 	 * Runs when you save the widget form. Allows you to validate or sanitize widget options before they are saved.
-	 *
 	 */
 	function update( $newinstance, $oldinstance ) {
 
@@ -424,7 +427,6 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 * Widget Output.
 	 *
 	 * Outputs the actual widget on the front-end based on the widget options the user selected.
-	 *
 	 */
 	function widget( $args, $instance ) {
 
@@ -435,37 +437,39 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 
 		echo $before_widget;
 
-			if ( ! empty( $instance['title'] ) )
-				echo $before_title . apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base ) . $after_title;
+		if ( ! empty( $instance['title'] ) ) {
+			echo $before_title . apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base ) . $after_title;
+		}
 
 			$output = '';
 
 			$profiles = (array) $this->profiles;
 
-			foreach ( $profiles as $profile => $data ) {
+		foreach ( $profiles as $profile => $data ) {
 
-				if ( empty( $instance[ $profile ] ) )
-					continue;
-
-				$new_window = $instance['new_window'] ? 'target="_blank" rel="noopener noreferrer"' : '';
-
-				if ( is_email( $instance[ $profile ] ) || false !== strpos( $instance[ $profile ], 'mailto:' ) )
-					$new_window = '';
-
-				if ( is_email( $instance[ $profile ] ) ) {
-					$output .= sprintf( $data['pattern'], 'mailto:' . esc_attr( antispambot( $instance[ $profile ] ) ), $new_window );
-				} elseif ( 'phone' === $profile ) {
-					$output .= sprintf( $data['pattern'], 'tel:' . esc_attr( antispambot( $instance[ $profile ] ) ), $new_window );
-				} else {
-					$output .= sprintf( $data['pattern'], esc_url( $instance[ $profile ] ), $new_window );
-				}
-
+			if ( empty( $instance[ $profile ] ) ) {
+				continue;
 			}
 
-			if ( $output ) {
-				$output = str_replace( '{WIDGET_INSTANCE_ID}', $this->number, $output );
-				printf( '<ul class="%s">%s</ul>', $instance['alignment'], $output );
+			$new_window = $instance['new_window'] ? 'target="_blank" rel="noopener noreferrer"' : '';
+
+			if ( is_email( $instance[ $profile ] ) || false !== strpos( $instance[ $profile ], 'mailto:' ) ) {
+				$new_window = '';
 			}
+
+			if ( is_email( $instance[ $profile ] ) ) {
+				$output .= sprintf( $data['pattern'], 'mailto:' . esc_attr( antispambot( $instance[ $profile ] ) ), $new_window );
+			} elseif ( 'phone' === $profile ) {
+				$output .= sprintf( $data['pattern'], 'tel:' . esc_attr( antispambot( $instance[ $profile ] ) ), $new_window );
+			} else {
+				$output .= sprintf( $data['pattern'], esc_url( $instance[ $profile ] ), $new_window );
+			}
+		}
+
+		if ( $output ) {
+			$output = str_replace( '{WIDGET_INSTANCE_ID}', $this->number, $output );
+			printf( '<ul class="%s">%s</ul>', $instance['alignment'], $output );
+		}
 
 		echo $after_widget;
 
@@ -487,7 +491,7 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		wp_enqueue_style( 'simple-social-icons-font', esc_url( $cssfile ), array(), $this->version, 'all' );
 
 		if ( ! function_exists( 'is_amp_endpoint' ) || ( function_exists( 'is_amp_endpoint' ) && ! is_amp_endpoint() ) ) {
-			wp_enqueue_script('svg-x-use', plugin_dir_url(__FILE__) . 'svgxuse.js', array(), '1.1.21' );
+			wp_enqueue_script( 'svg-x-use', plugin_dir_url( __FILE__ ) . 'svgxuse.js', array(), '1.1.21' );
 		}
 	}
 
@@ -563,7 +567,7 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 * @return string The full markup for the given icon.
 	 */
 	function get_icon_markup( $icon, $label ) {
-		$markup = '<li class="ssi-' . $icon . '"><a href="%s" %s>';
+		$markup  = '<li class="ssi-' . $icon . '"><a href="%s" %s>';
 		$markup .= '<svg role="img" class="social-' . $icon . '" aria-labelledby="social-' . $icon . '-{WIDGET_INSTANCE_ID}">';
 		$markup .= '<title id="social-' . $icon . '-{WIDGET_INSTANCE_ID}' . '">' . $label . '</title>';
 		$markup .= '<use xlink:href="' . esc_attr( plugin_dir_url( __FILE__ ) . 'symbol-defs.svg#social-' . $icon ) . '"></use>';
@@ -599,7 +603,6 @@ add_action( 'widgets_init', 'ssiw_load_widget' );
  * Widget Registration.
  *
  * Register Simple Social Icons widget.
- *
  */
 function ssiw_load_widget() {
 

--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -23,6 +23,9 @@ function simple_social_icons_load_textdomain() {
 	load_plugin_textdomain( 'simple-social-icons', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
 }
 
+/**
+ * The Simple Social Icons widget.
+ */
 class Simple_Social_Icons_Widget extends WP_Widget {
 
 	/**
@@ -72,7 +75,7 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 *
 	 * Set some global values and create widget.
 	 */
-	function __construct() {
+	public function __construct() {
 
 		/**
 		 * Filter for default widget option values.
@@ -270,9 +273,11 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 * Color Picker.
 	 *
 	 * Enqueue the color picker script.
+     *
+     * @param string $hook The current admin page.
 	 */
-	function load_color_picker( $hook ) {
-		if ( 'widgets.php' != $hook ) {
+	public function load_color_picker( $hook ) {
+		if ( 'widgets.php' !== $hook ) {
 			return;
 		}
 			wp_enqueue_style( 'wp-color-picker' );
@@ -285,7 +290,7 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 *
 	 * Reference https://core.trac.wordpress.org/attachment/ticket/25809/color-picker-widget.php
 	 */
-	function print_scripts() {
+	public function print_scripts() {
 		?>
 		<script>
 			( function( $ ){
@@ -321,6 +326,8 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 	 * Widget Form.
 	 *
 	 * Outputs the widget form that allows users to control the output of the widget.
+	 *
+	 * @param array $instance The widget settings.
 	 */
 	function form( $instance ) {
 


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->
- [x] Fix `composer phpcs` issues
- [x] Add more escaping where needed 
- [x] Bump version to `3.1.0` in preparation for a release

### How to test
<!-- Detailed steps to test this PR. -->
1. No build steps needed for this plugin, like `npm run dev`, etc…
2. Activate Twenty Twenty-One, or any non-FSE theme
3. Go to the Customizer
4. Add the 'Simple Social Icons' widget
5. Populate all of the fields. For testing, URLs can all simply be `https://example.com`.
6. Expected: The widget's markup has the edits that you made in the fields: 
<img width="778" alt="Screen Shot 2022-04-04 at 4 44 17 PM" src="https://user-images.githubusercontent.com/4063887/161637439-4b9b05e2-01a1-4a9e-b066-0999767662a8.png">

### Documentation
 No documentation required (I think)
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Add escaping to the widget's output

<!-- Additional information for reviewers. -->
