### PR TITLE
Allow removing files from the svn repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,12 +60,6 @@ commands:
       - set_version_variable
       - run: svn cp trunk tags/${VERSION}
 
-  svn_commit:
-    description: "Commit changes to SVN"
-    steps:
-      - set_version_variable
-      - run: svn ci -m "Tagging ${VERSION} from Github" --no-auth-cache --non-interactive --username "${SVN_USERNAME}" --password "${SVN_PASSWORD}"
-
 executors:
   base:
     docker:
@@ -104,7 +98,6 @@ jobs:
           at: /tmp
       - svn_setup
       - svn_add_changes
-      - svn_commit
 
   deploy_svn_tag:
     executor: base
@@ -115,7 +108,6 @@ jobs:
       - svn_setup
       - svn_create_tag
       - svn_add_changes
-      - svn_commit
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,11 +54,7 @@ commands:
     description: "Create a SVN tag"
     steps:
       - set_version_variable
-      - run:
-          command: |
-            svn up tags/${VERSION}
-            svn rm tags/${VERSION} &>/dev/null
-            svn cp trunk tags/${VERSION}
+      - run: svn cp trunk tags/${VERSION}
 
   svn_commit:
     description: "Commit changes to SVN"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,12 @@ commands:
     description: "Add changes to SVN"
     steps:
       - run:
-          command: if [[ ! -z $(svn st | grep ^\!) ]]; then svn st | grep ^! | awk '{print " --force "$2}' | xargs -0r svn rm; fi
-      - run: svn add --force .
+          command: |
+            SVN_DIRECTORIES="trunk tags"
+            svn stat $SVN_DIRECTORIES | { grep -E '^\?' || true; } | awk '{print $2}' | xargs -r svn add
+            svn stat $SVN_DIRECTORIES | { grep -E '^\!' || true; } | awk '{print $2}' | xargs -r svn rm
+            echo "Here is the svn stat about to be checked in:"
+            svn stat
 
   svn_create_tag:
     description: "Create a SVN tag"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,18 @@ commands:
           command: |
             [ ! -d "/tmp/artifacts" ] && mkdir /tmp/artifacts &>/dev/null
 
-  set_verision_variable:
+  set_version_variable:
     description: "Set the VERSION environment variable"
     steps:
       - run:
           command: |
-            echo "export VERSION=$(grep 'Version:' /tmp/src/simple-social-icons.php | awk -F: '{print $2}' | sed 's/^\s//')" >> ${BASH_ENV}
+            PLUGIN_VERSION=$(grep 'Version:' /tmp/src/simple-social-icons.php | awk -F: '{print $2}' | sed 's/^\s//')
+            if [ ! $PLUGIN_VERSION ]
+              then
+              echo "Didn't find a version of the plugin"
+              exit 1
+            fi
+            echo "export VERSION=$PLUGIN_VERSION" >> ${BASH_ENV}
 
   show_pwd_info:
     description: "Show information about the current directory"
@@ -47,13 +53,17 @@ commands:
   svn_create_tag:
     description: "Create a SVN tag"
     steps:
-      - set_verision_variable
-      - run: svn cp trunk tags/${VERSION}
+      - set_version_variable
+      - run:
+          command: |
+            svn up tags/${VERSION}
+            svn rm tags/${VERSION} &>/dev/null
+            svn cp trunk tags/${VERSION}
 
   svn_commit:
     description: "Commit changes to SVN"
     steps:
-      - set_verision_variable
+      - set_version_variable
       - run: svn ci -m "Tagging ${VERSION} from Github" --no-auth-cache --non-interactive --username "${SVN_USERNAME}" --password "${SVN_PASSWORD}"
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,12 @@ commands:
       - set_version_variable
       - run: svn cp trunk tags/${VERSION}
 
+  svn_commit:
+    description: "Commit changes to SVN"
+    steps:
+      - set_version_variable
+      - run: svn ci -m "Tagging ${VERSION} from Github" --no-auth-cache --non-interactive --username "${SVN_USERNAME}" --password "${SVN_PASSWORD}"
+
 executors:
   base:
     docker:
@@ -97,6 +103,7 @@ jobs:
           at: /tmp
       - svn_setup
       - svn_add_changes
+      - svn_commit
 
   deploy_svn_tag:
     executor: base
@@ -107,6 +114,7 @@ jobs:
       - svn_setup
       - svn_create_tag
       - svn_add_changes
+      - svn_commit
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,8 @@ commands:
     steps:
       - run:
           command: |
-            SVN_DIRECTORIES="trunk tags"
-            svn stat $SVN_DIRECTORIES | { grep -E '^\?' || true; } | awk '{print $2}' | xargs -r svn add
-            svn stat $SVN_DIRECTORIES | { grep -E '^\!' || true; } | awk '{print $2}' | xargs -r svn rm
+            svn stat | { grep -E '^\?' || true; } | awk '{print $2}' | xargs -r svn add
+            svn stat | { grep -E '^\!' || true; } | awk '{print $2}' | xargs -r svn rm
             echo "Here is the svn stat about to be checked in:"
             svn stat
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
             svn stat | { grep -E '^\?' || true; } | awk '{print $2}' | xargs -r svn add
             svn stat | { grep -E '^\!' || true; } | awk '{print $2}' | xargs -r svn rm
             echo "Here is the svn stat about to be checked in:"
-            svn stat
+            svn stat --verbose
 
   svn_create_tag:
     description: "Create a SVN tag"

--- a/.svnignore
+++ b/.svnignore
@@ -1,7 +1,9 @@
 .git
 .gitignore
 .gitattributes
-.phpcs.xml
 .svnignore
 node_modules
 .circleci
+phpcs.xml
+composer.json
+composer.lock


### PR DESCRIPTION
In response to an [error](https://app.circleci.com/pipelines/github/studiopress/simple-social-icons/47/workflows/18bb48ba-02ad-44a1-896b-839987ae2913/jobs/116) before deploying, from the deletion of `svgxuse.js`.

The [main fix](https://github.com/studiopress/simple-social-icons/pull/117/files#r852321818) is to not attempt to add files that were deleted, like `svgxuse.js`
<!-- A short but detailed summary of the changes. -->

<!-- Fixes #xxx. -->
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
Manually run some of these `svn` commands, though of course without doing `svn ci`

### Documentation
No documentation required.
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->


### Notes
<!-- Additional information for reviewers. -->
Here's the [result](https://github.com/studiopress/simple-social-icons/pull/117#discussion_r852308357) of running this PR locally. It looks right, but the real test will be on wp.org.