### PR TITLE
Copy new additions from `README.md` to `readme.txt`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,15 @@ NOTE - The rights to each pictogram in the social extension are either trademark
 
 == Changelog ==
 
+= 3.1.1 =
+* Added Amazon, Goodreads, Meetup, Reddit, TikTok, Tripadvisor, and WhatsApp icons
+* Updated GitHub icon
+* Removed Google+ and StumbleUpon icons
+
+= 3.1.0 =
+* Add escaping to output
+* Remove the svgxuse.js script
+
 = 3.0.2 =
 * Fixed issue where icons can fail if there is a space anywhere in its URL.
 

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ This will remove icon styling options in the widget settings, and prevent Simple
 
 = Which services are included? =
 
+* Amazon
 * Behance
 * Bloglovin
 * Dribbble
@@ -47,19 +48,23 @@ This will remove icon styling options in the widget settings, and prevent Simple
 * Facebook
 * Flickr
 * Github
-* Google+
+* Goodreads
 * Instagram
 * LinkedIn
 * Medium
+* Meetup
 * Periscope
 * Phone
 * Pinterest
+* Reddit
 * RSS
 * Snapchat
-* StumbleUpon
+* TikTok
+* Tripadvisor
 * Tumblr
 * Twitter
 * Vimeo
+* WhatsApp
 * Xing
 * YouTube
 


### PR DESCRIPTION
* My fault, I should have caught this before, that `README.md` and `readme.txt` are basically the same, but `readme.txt` is the one wp.org uses
* This can probably go out in the next release, probably not urgent

### How to test
<!-- Detailed steps to test this PR. -->
Not needed

