### PR TITLE
Only enqueue style when widget is loaded

### DIFF
--- a/simple-social-icons.php
+++ b/simple-social-icons.php
@@ -551,8 +551,9 @@ class Simple_Social_Icons_Widget extends WP_Widget {
 		 * @param string $cssfile The full path to the stylesheet.
 		 */
 		$cssfile = apply_filters( 'simple_social_default_stylesheet', plugin_dir_url( __FILE__ ) . 'css/style.css' );
-
-		wp_enqueue_style( 'simple-social-icons-font', esc_url( $cssfile ), array(), $this->version, 'all' );
+		if ( is_active_widget( false, false, $this->id_base, true ) ) {
+			wp_enqueue_style( 'simple-social-icons-font', esc_url( $cssfile ), array(), $this->version, 'all' );
+		};
 	}
 
 	/**


### PR DESCRIPTION
This change to the simple-social-icons.php file will only load the CSS if the widget is uploaded. This was mentioned in issue #99.

The fix is to add an if statement: `if ( is_active_widget( false, false, $this->id_base, true ) )` for: `wp_enqueue_style()`